### PR TITLE
Feature/back/batch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,12 @@ poetry run python manage.py createsuperuser
 
 - [http://localhost:8000/admin](http://localhost:8000/admin)で管理画面が表示されます
 - superuser作成時に入力したemail, passwordでログインして下さい
+
+
+### APSchedulerの起動
+
+- 下記のカスタムコマンドで、設定されているAPSchedulerのスケジュールが起動・待機します
+- entrypoint.shにバックグラウンド実行で記載しているため、通常はコンテナ起動時に自動で動きます
+```bash
+poetry run python manage.py runapscheduler
+```

--- a/apps/apps.py
+++ b/apps/apps.py
@@ -4,8 +4,3 @@ from django.apps import AppConfig
 class AppsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps'
-
-    # ap_scheduler起動処理を追加
-    def ready(self):
-        from .batch import start
-        start()

--- a/apps/batch.py
+++ b/apps/batch.py
@@ -4,7 +4,6 @@ from django.db import IntegrityError
 from django.db.models import Q
 from zoneinfo import ZoneInfo
 from dateutil.relativedelta import relativedelta
-from apscheduler.schedulers.background import BackgroundScheduler
 from .models import PastSchedule, Schedule, ExceptionalSchedule
 from .utils.calendar_utils import get_recurrenced_and_exceptional_dates
 
@@ -72,9 +71,3 @@ def insert_past_schedules():
     except Exception as e:
         logger.error(f'error: {str(e)}')
 
-
-# APScheduler:毎日0:00にinsert_past_schedulesを実行する
-def start():
-    scheduler = BackgroundScheduler()
-    scheduler.add_job(insert_past_schedules, 'cron', hour=0, minute=0)
-    scheduler.start()

--- a/apps/management/commands/runapscheduler.py
+++ b/apps/management/commands/runapscheduler.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         scheduler = BlockingScheduler()
-        scheduler.add_job(insert_past_schedules, 'cron', hour=0, minute=27)
+        scheduler.add_job(insert_past_schedules, 'cron', hour=1, minute=7)
         self.stdout.write('Scheduler started.')
         try:
             scheduler.start()

--- a/apps/management/commands/runapscheduler.py
+++ b/apps/management/commands/runapscheduler.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apps.batch import insert_past_schedules
+
+class Command(BaseCommand):
+    help = 'Run APScheduler using BlockingScheduler'
+
+    def handle(self, *args, **kwargs):
+        scheduler = BlockingScheduler()
+        scheduler.add_job(insert_past_schedules, 'cron', hour=0, minute=27)
+        self.stdout.write('Scheduler started.')
+        try:
+            scheduler.start()
+        except KeyboardInterrupt:
+            scheduler.shutdown()
+            self.stdout.write('Scheduler stopped.')

--- a/apps/management/commands/runapscheduler.py
+++ b/apps/management/commands/runapscheduler.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         scheduler = BlockingScheduler()
-        scheduler.add_job(insert_past_schedules, 'cron', hour=1, minute=7)
+        scheduler.add_job(insert_past_schedules, 'cron', hour=0, minute=0)
         self.stdout.write('Scheduler started.')
         try:
             scheduler.start()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 
+# エラー時に即終了
+set -e
+
 # DBのマイグレーション
 poetry run python manage.py migrate --noinput
 
 # Nginxを使う時用
 # poetry run python manage.py collectstatic --noinput
 
-# 開発サーバーの起動
+# APSchedulerをバックグラウンドで起動
+poetry run python manage.py runapscheduler &
+
+# 開発サーバーをフォアグラウンドで起動
 # 起動したくないときはコメントアウト→下のtail～が代わりに常駐プロセスとして待機する
 poetry run python manage.py runserver 0.0.0.0:8000
 


### PR DESCRIPTION
### やったこと

- APSchedulerによるバッチ処理を、開発サーバーでの起動→Djangoのカスタムコマンドでの単独起動へ変更
- それに伴い、schedulerの種類をBackgroundScheduler（メインと並列）→BlockingScheduler（単独）へ変更
- APScheduler起動のカスタムコマンドをentrypoint.shへバックグラウンド実行として追記→コンテナ起動時に自動スタートするようにした


### 動作の確認方法

1. コンテナ起動前に、apps/management/commands/runapscheduler.pyの10行目：scheduler.add_job(insert_past_schedules, 'cron', hour=0, minute=0)のhour, minuteを、確認用に動作させたい時間に変更する

2. 上記で設定した時間までに、コンテナを起動させる（開発サーバー、APSchedulerは自動で起動します）

3. 設定した時間になると自動で処理が行われる。その際、DockerDesktopのコンテナ内ログには処理結果やエラー等のログが出ます。また、phpMyAdmin等で、DBにデータが入っているか確認する

※変更した時間設定は、必ず元の時間（0:00）に戻しておいてください
※DBにすでにあるデータをinsertしようとするとエラーになります。複数回試す場合は、対象レコードを一旦削除して行って下さい