### PR TITLE
Feature/back/edit 

### DIFF
--- a/apps/forms.py
+++ b/apps/forms.py
@@ -142,7 +142,7 @@ class ScheduleForm(forms.ModelForm):
             monthly_option = self.data.get("monthly_option")
             if monthly_option == "by_date":
                 cleaned_data["day_of_week"] = None
-                cleaned_data["nth_weekday"] = None
+                cleaned_data["day_of_week"] = None
 
         return cleaned_data
 
@@ -156,10 +156,12 @@ class ScheduleForm(forms.ModelForm):
         self.user = user
         super().__init__(*args, **kwargs)
 
-        # frequencyが「なし」以外のときは interval の初期値を1に
-        frequency = self.data.get('frequency') or self.initial.get('frequency')
-        if frequency and frequency != 'NONE':  # ← 'none' はFREQUENCY_CHOICESの値に合わせてください
-            self.fields['interval'].initial = 1
+        
+        if not self.data:
+            frequency = self.initial.get('frequency') or (self.instance and self.instance.frequency)
+            interval = self.initial.get('interval') or (self.instance and self.instance.interval)
+            if frequency and frequency != 'NONE' and interval is None:
+                self.fields['interval'].initial = 1
 
         #  当日の日付を初期値に設定（ただし既に指定されていないときだけ上書きしないように）
         if not self.initial.get('start_date') and not self.data.get('start_date'):
@@ -223,6 +225,23 @@ class ScheduleEditForm(ScheduleForm):
         # start_date に初期値がなければ instance.start_date を使う
         if not self.fields['start_date'].initial:
             self.fields['start_date'].initial = self.instance.start_date
+
+
+
+        # start_date に初期値がなければ instance.start_date を使う
+        if not self.fields['start_date'].initial:
+            self.fields['start_date'].initial = self.instance.start_date
+            self.fields['day_of_week'].initial = self.instance.day_of_week
+            self.fields['nth_weekday'].initial = self.instance.nth_weekday
+            self.fields['frequency'].initial = self.instance.frequency
+            self.fields['interval'].initial = self.instance.interval
+            self.fields['memo'].initial = self.instance.memo
+            self.fields['start_date'].initial = self.instance.start_date
+
+        # intervalフィールドのinputにCSSクラスを追加
+        self.fields['interval'].widget.attrs.update({'class': 'interval'})
+
+
 
 
 

--- a/apps/views/schedules_views.py
+++ b/apps/views/schedules_views.py
@@ -86,7 +86,7 @@ class ScheduleCreateView(LoginRequiredMixin, CreateView):
         return initial
     
     def get_form_kwargs(self):
-        """フォームにログインユーザーを渡す"""
+        """フォームにログインユーザー・カテゴリ。リクエストを渡す"""
         kwargs = super().get_form_kwargs()
 
         user = self.request.user
@@ -95,6 +95,7 @@ class ScheduleCreateView(LoginRequiredMixin, CreateView):
             user = user._wrapped
 
         kwargs['user'] = user
+        kwargs['request'] = self.request
         task_category_id = self.request.POST.get('task_category') or self.request.GET.get('task_category')
         kwargs['task_category_id'] = task_category_id
         return kwargs

--- a/apps/views/schedules_views.py
+++ b/apps/views/schedules_views.py
@@ -161,6 +161,16 @@ class ScheduleEditAsNewView(LoginRequiredMixin, UpdateView):
         form.initial['start_date'] = get_most_recent_reccurenced_date(schedule, today)
         return form
 
+    
+    
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        schedule = self.get_object()
+        today = date.today()
+        form.initial['start_date'] = get_most_recent_reccurenced_date(schedule, today)
+        return form
+
+
     def form_valid(self, form):
        # 上書き保存するだけ
         schedule = form.save(commit=False)

--- a/static/js/schedule_edit.js
+++ b/static/js/schedule_edit.js
@@ -1,4 +1,353 @@
 console.log("schedule_edit.js 読み込み成功！");
+
+
+$(document).ready(function () {
+    console.log("Before JS:", $("#id_nth_weekday").val());
+
+    setTimeout(() => {
+        console.log("After updateYearlyOptionsFromStartDate:", $("#id_nth_weekday").val());
+    }, 1000);
+    initScheduleForm();
+});
+
+function initScheduleForm() {
+    $("#interval-field, #day-of-week-field, #nth-weekday-field").hide();
+    updateStartDateWeekday();
+    initFrequencyButtonSelection();
+    bindFrequencyButtons();
+    bindStartDateChange();
+    bindMonthlyOptionChange();
+    bindYearlyOptionChange();
+    triggerInitialFrequency();
+    // setInitialFrequencyState();
+    updateMonthlyAndYearlyOptionRadios();
+}
+
+// --- 初期表示関連 ---
+function initFrequencyButtonSelection() {
+    const frequency = $("#id_frequency").val();
+    if (!frequency) return;
+    $(".frequency-buttons").removeClass("active");
+    $(`.frequency-buttons[data-value="${frequency}"]`).addClass("active");
+}
+
+function triggerInitialFrequency() {
+    const initialFreq = $("#id_frequency").val();
+    if (!initialFreq) return;
+
+    // クリックイベント発火
+    $(`#frequency-buttons button[data-value='${initialFreq}']`).trigger("click");
+
+    // クリックイベントの中で interval は初期値1にリセットされてしまうので、
+    // ここでフォームにある interval の値を再セットする
+    const initialInterval = $("#id_interval").data("initial-value");
+    if (initialInterval) {
+        $("#id_interval").val(initialInterval);
+    }
+}
+
+// --- 曜日表示更新 ---
+function updateStartDateWeekday() {
+    const dateStr = $("#id_start_date").val();
+    if (!dateStr) return $("#start-date-weekday").text("");
+
+    const dateObj = new Date(dateStr);
+    if (isNaN(dateObj)) return $("#start-date-weekday").text("");
+
+    const dayNames = ["日", "月", "火", "水", "木", "金", "土"];
+    $("#start-date-weekday").text(`(${dayNames[dateObj.getDay()]})`);
+}
+
+// --- 曜日関連処理 ---
+function showOnlySelectedWeekday(selectedDay) {
+    $(".day-label").each(function () {
+        const $input = $(this).find("input[type=radio]");
+        if ($(this).data("day") === selectedDay) {
+            $(this).show();
+            $input.prop("checked", true);
+        } else {
+            $(this).hide();
+            $input.prop("checked", false);
+        }
+    });
+}
+
+function setDayOfWeekFromStartDate() {
+    const dateStr = $("#id_start_date").val();
+    if (!dateStr) return;
+
+    const dateObj = new Date(dateStr);
+    if (isNaN(dateObj)) return;
+
+    const jsDayToDjangoCode = ["SU", "MO", "TU", "WE", "TH", "FI", "SA"];
+    const djangoDay = jsDayToDjangoCode[dateObj.getDay()];
+
+    if ($("#id_frequency").val() === "WEEKLY") {
+        showOnlySelectedWeekday(djangoDay);
+    } else {
+        $(".day-label").show();
+        $("input[name='day_of_week']").prop("checked", false);
+    }
+}
+
+// --- 毎月繰り返し関連 ---
+function updateMonthlyOptionsFromStartDate() {
+    const dateStr = $("#id_start_date").val();
+    if (!dateStr) return;
+
+    const dateObj = new Date(dateStr);
+    if (isNaN(dateObj)) return;
+
+    const d = dateObj.getDate();
+    $("#monthly-date-info").text(`${d}日`);
+
+    const info = getOrdinalWeekdayInfo(dateObj);
+    $("#monthly-weekday-info").text(info.label);
+
+    if (!$("#id_nth_weekday").val()) {
+        $("#id_nth_weekday").val(info.nth + 1);
+    }
+
+    if (!$("input[name='day_of_week']:checked").val()) {
+        $("input[name='day_of_week']").prop("checked", false);
+        $(`input[name='day_of_week'][value='${info.djangoDay}']`).prop("checked", true);
+    }
+}
+
+// --- 毎年繰り返し関連 ---
+function updateYearlyOptionsFromStartDate() {
+    const dateStr = $("#id_start_date").val();
+    if (!dateStr) return;
+
+    const dateObj = new Date(dateStr);
+    if (isNaN(dateObj)) return;
+
+    const m = dateObj.getMonth() + 1;
+    const d = dateObj.getDate();
+    $("#yearly-date-info").text(`${m}月${d}日`);
+
+    const info = getOrdinalWeekdayInfo(dateObj);
+    $("#yearly-weekday-info").text(`${m}月${info.label}`);
+
+    if (!$("#id_nth_weekday").val()) {
+        $("#id_nth_weekday").val(info.nth + 1);
+    }
+
+    if (!$("input[name='day_of_week']:checked").val()) {
+        $("input[name='day_of_week']").prop("checked", false);
+        $(`input[name='day_of_week'][value='${info.djangoDay}']`).prop("checked", true);
+    }
+}
+
+// --- 共通：第何週何曜日を取得 ---
+function getOrdinalWeekdayInfo(dateObj) {
+    const jsDay = dateObj.getDay();
+    const jsDayToDjangoCode = ["SU", "MO", "TU", "WE", "TH", "FI", "SA"];
+    const djangoDay = jsDayToDjangoCode[jsDay];
+    const nth = Math.floor((dateObj.getDate() - 1) / 7);
+    const weekNames = ["第1", "第2", "第3", "第4", "第5"];
+    const dayNames = ["日", "月", "火", "水", "木", "金", "土"];
+    return {
+        nth,
+        djangoDay,
+        label: `${weekNames[nth]}${dayNames[jsDay]}曜日`
+    };
+}
+
+// --- ボタン操作 ---
+function bindFrequencyButtons() {
+    $("#frequency-buttons button").click(function () {
+        const value = $(this).data("value");
+        $("#id_frequency").val(value);
+        $("#frequency-buttons button").removeClass("selected");
+        $(this).addClass("selected");
+
+        $("#interval-field, #day-of-week-field, #nth-weekday-field").hide();
+        $(".monthly-options, .yearly-options").hide();
+        $(".field-help").text("");
+        $(".day-label").show();
+        $("input[name='day_of_week']").prop("checked", false);
+
+        // if (value !== "NONE") {
+        //     $("#id_interval").val(1);
+        // } else {
+        //     $("#id_interval").val("");
+        // }
+
+        if (value !== "NONE") {
+            const currentInterval = $("#id_interval").val();
+            // interval が空 or 0 の場合のみ1に設定する
+            if (!currentInterval || currentInterval === "0") {
+                $("#id_interval").val(1);
+            }
+        } else {
+            $("#id_interval").val("");
+        }
+
+        switch (value) {
+            case "DAILY":
+                $("#interval-field").show();
+                $("#interval-help").text("日ごと");
+                break;
+            case "WEEKLY":
+                $("#interval-field, #day-of-week-field").show();
+                $("#interval-help").text("週間ごと");
+                setDayOfWeekFromStartDate();
+                break;
+            case "MONTHLY":
+                $("#interval-field, #nth-weekday-field").show();
+                $(".monthly-options").show();
+                $("#interval-help").text("か月ごと");
+                updateMonthlyOptionsFromStartDate();
+                $("input[name='monthly_option'][value='by_date']").prop("checked", true);
+                $("#monthly-nth-weekday-selects").hide();
+                break;
+            case "YEARLY":
+                $("#interval-field, #nth-weekday-field").show();
+                $(".yearly-options").show();
+                $("#interval-help").text("年ごと");
+                updateYearlyOptionsFromStartDate();
+                break;
+        }
+    });
+}
+
+// --- イベントバインド ---
+function bindStartDateChange() {
+    $("#id_start_date").change(function () {
+        updateStartDateWeekday();
+        const freq = $("#id_frequency").val();
+        $(`#frequency-buttons button[data-value='${freq}']`).addClass("selected");
+
+        switch (freq) {
+            case "WEEKLY":
+                $("#interval-field, #day-of-week-field").show();
+                setDayOfWeekFromStartDate();
+                break;
+            case "MONTHLY":
+                $("#interval-field, #nth-weekday-field").show();
+                $(".monthly-options").show();
+                updateMonthlyOptionsFromStartDate();
+                if ($("input[name='monthly_option']:checked").val() === "by_weekday") {
+                    $("#monthly-nth-weekday-selects").show();
+                }
+                break;
+            case "YEARLY":
+                $("#interval-field, #nth-weekday-field").show();
+                $(".yearly-options").show();
+                updateYearlyOptionsFromStartDate();
+                break;
+        }
+    });
+}
+
+function bindMonthlyOptionChange() {
+    $("input[name='monthly_option']").change(function () {
+        if ($(this).val() === "by_date") {
+            $("#monthly-nth-weekday-selects").hide();
+            $("#id_day_of_week").val("");
+        } else {
+            $("#monthly-nth-weekday-selects").hide();
+        }
+    });
+}
+
+function bindYearlyOptionChange() {
+    $("input[name='yearly_option']").change(function () {
+        if ($(this).val() === "by_date") {
+            $("#yearly-nth-weekday-selects").hide();
+            $("#id_day_of_week").val("");
+        } else {
+            $("#yearly-nth-weekday-selects").hide();
+        }
+    });
+}
+
+function updateMonthlyAndYearlyOptionRadios() {
+    const dayOfWeek = $("input[name='day_of_week']:checked").val();
+    const nthWeekday = $("#id_nth_weekday").val();  // 選択されている値
+    const hasWeekdayRule = dayOfWeek || nthWeekday;
+
+    if (hasWeekdayRule) {
+        $("input[name='monthly_option'][value='by_weekday']").prop("checked", true);
+        $("input[name='yearly_option'][value='by_weekday']").prop("checked", true);
+    } else {
+        $("input[name='monthly_option'][value='by_date']").prop("checked", true);
+        $("input[name='yearly_option'][value='by_date']").prop("checked", true);
+    }
+}
+
+function setInitialFrequencyState() {
+    const initialFreq = $("#id_frequency").val();
+    if (!initialFreq) return;
+
+    // 全ボタンの selected クラスを外す
+    $("#frequency-buttons button").removeClass("selected");
+    // 初期 frequency に該当するボタンに selected を付ける
+    $(`#frequency-buttons button[data-value='${initialFreq}']`).addClass("selected");
+
+    // interval, day_of_week, nth_weekday のフォーム値はそのまま使うので、ここでは変更しない
+
+    // まず、表示を全て隠す
+    $("#interval-field, #day-of-week-field, #nth-weekday-field").hide();
+    $(".monthly-options, .yearly-options").hide();
+    $(".field-help").text("");
+    $(".day-label").show();
+    $("input[name='day_of_week']").prop("checked", false);
+
+    // frequency によって表示切替
+    switch (initialFreq) {
+        case "NONE":
+            $("#id_interval").val("");
+            break;
+        case "DAILY":
+            $("#interval-field").show();
+            $("#interval-help").text("日ごと");
+            break;
+        case "WEEKLY":
+            $("#interval-field, #day-of-week-field").show();
+            $("#interval-help").text("週間ごと");
+            // day_of_week はフォームの値を反映しているはずなのでチェックは不要
+            break;
+        case "MONTHLY":
+            $("#interval-field, #nth-weekday-field").show();
+            $(".monthly-options").show();
+            $("#interval-help").text("か月ごと");
+
+            // 月毎のオプション選択はフォーム値に合わせて
+            const monthlyOption = $("input[name='monthly_option']:checked").val() || "by_date";
+            $("input[name='monthly_option'][value='" + monthlyOption + "']").prop("checked", true);
+
+            // by_dateならnth_weekdayは隠す(by_weekdayなら表示)
+            if (monthlyOption === "by_date") {
+                $("#monthly-nth-weekday-selects").hide();
+            } else {
+                $("#monthly-nth-weekday-selects").show();
+            }
+            break;
+        case "YEARLY":
+            $("#interval-field, #nth-weekday-field").show();
+            $(".yearly-options").show();
+            $("#interval-help").text("年ごと");
+
+            // yearly_option はフォームの値に合わせて選択
+            const yearlyOption = $("input[name='yearly_option']:checked").val() || "by_date";
+            $("input[name='yearly_option'][value='" + yearlyOption + "']").prop("checked", true);
+
+            if (yearlyOption === "by_date") {
+                $("#yearly-nth-weekday-selects").hide();
+            } else {
+                $("#yearly-nth-weekday-selects").show();
+                // 必要ならここで nth_weekday の値セットも
+            }
+            break;
+    }
+}
+
+
+
+
+
 document.addEventListener("DOMContentLoaded", function () {
     const deleteModal = document.getElementById("delete-modal");
     const openDeleteModalBtn = document.getElementById("open-delete-modal");

--- a/static/js/schedule_form.js
+++ b/static/js/schedule_form.js
@@ -21,9 +21,39 @@ $("#id_task_category").change(function () {
 
 
 $(document).ready(function () {
+    const urlParams = new URLSearchParams(window.location.search);
+    const dateParam = urlParams.get("date");
+
+    if (dateParam) {
+        console.log("URLのdateパラメータ:", dateParam);
+        const $input = $("#id_start_date");
+
+        const inputDate = new Date(dateParam + 'T00:00:00'); // 日付文字列を Date に変換
+        const today = new Date();
+        const todayDateOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+        let setDate;
+        if (inputDate < todayDateOnly) {
+            setDate = todayDateOnly;
+        } else {
+            setDate = inputDate;
+        }
+
+        // ここで dateStr を定義
+        const y = setDate.getFullYear();
+        const m = String(setDate.getMonth() + 1).padStart(2, '0');
+        const d = String(setDate.getDate()).padStart(2, '0');
+        const dateStr = `${y}-${m}-${d}`;
+
+        // ここで使う
+        console.log("設定する日付:", dateStr);
+        $input.val(dateStr);
+        $input.trigger("change");
+    }
+
     // 初期は全フィールド非表示
     $("#interval-field, #day-of-week-field, #nth-weekday-field").hide();
-
+    
     // 曜日コードマップ（日曜=0〜土曜=6 → Djangoの曜日コード）
     const jsDayToDjangoCode = ["SU", "MO", "TU", "WE", "TH", "FI", "SA"];
 
@@ -244,3 +274,4 @@ $(document).ready(function () {
     }
     updateStartDateWeekday();
 });
+

--- a/templates/schedules/edit_schedules.html
+++ b/templates/schedules/edit_schedules.html
@@ -8,7 +8,7 @@
 <!-- jQuery -->
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
-<script src="/static/js/schedule_form.js" defer></script>
+<!-- <script src="/static/js/schedule_form.js" defer></script> -->
 <script src="/static/js/schedule_edit.js" defer></script>
 {% endblock %}
 
@@ -71,23 +71,33 @@
     <!-- frequency に応じて表示する項目 -->
     <div id="frequency-extra-fields">
         <div id="interval-field" class="margin10">
-            <input type="number" name="interval" id="id_interval" min="1" class="interval">
+            <input type="number" name="interval" id="id_interval" 
+       value="{{ form.interval.value|default:'1' }}" 
+       data-initial-value="{{ form.interval.value|default:'1' }}" class="interval">
+            
             <span class="field-help" id="interval-help"></span>
         </div>
         <div id="day-of-week-field">
-            <label class="day-label" data-day="MO"><input type="radio" name="day_of_week" value="MO" id="day-MO">
+            <label class="day-label" data-day="MO"><input type="radio" name="day_of_week" value="MO" id="day-MO"
+                {% if form.day_of_week.value == 'MO' %}checked{% endif %}>
                 月曜日</label>
-            <label class="day-label" data-day="TU"><input type="radio" name="day_of_week" value="TU" id="day-TU">
+            <label class="day-label" data-day="TU"><input type="radio" name="day_of_week" value="TU" id="day-TU"
+                {% if form.day_of_week.value == 'TU' %}checked{% endif %}>
                 火曜日</label>
-            <label class="day-label" data-day="WE"><input type="radio" name="day_of_week" value="WE" id="day-WE">
+            <label class="day-label" data-day="WE"><input type="radio" name="day_of_week" value="WE" id="day-WE"
+                {% if form.day_of_week.value == 'WE' %}checked{% endif %}>
                 水曜日</label>
-            <label class="day-label" data-day="TH"><input type="radio" name="day_of_week" value="TH" id="day-TH">
+            <label class="day-label" data-day="TH"><input type="radio" name="day_of_week" value="TH" id="day-TH"
+                {% if form.day_of_week.value == 'TH' %}checked{% endif %}>
                 木曜日</label>
-            <label class="day-label" data-day="FI"><input type="radio" name="day_of_week" value="FI" id="day-FI">
+            <label class="day-label" data-day="FI"><input type="radio" name="day_of_week" value="FI" id="day-FI"
+                {% if form.day_of_week.value == 'FI' %}checked{% endif %}>
                 金曜日</label>
-            <label class="day-label" data-day="SA"><input type="radio" name="day_of_week" value="SA" id="day-SA">
+            <label class="day-label" data-day="SA"><input type="radio" name="day_of_week" value="SA" id="day-SA"
+                {% if form.day_of_week.value == 'SA' %}checked{% endif %}>
                 土曜日</label>
-            <label class="day-label" data-day="SU"><input type="radio" name="day_of_week" value="SU" id="day-SU">
+            <label class="day-label" data-day="SU"><input type="radio" name="day_of_week" value="SU" id="day-SU"
+                {% if form.day_of_week.value == 'SU' %}checked{% endif %}>
                 日曜日</label>
             <span class="field-help" id="day-of-week-help"></span>
         </div>
@@ -96,13 +106,15 @@
             <div class="monthly-options">
                 <div class="margin10">
                     <label>
-                        <input type="radio" name="monthly_option" value="by_date" checked>
+                        <input type="radio" name="monthly_option" value="by_date"
+                        {% if not form.day_of_week.value and not form.nth_weekday.value %}checked{% endif %}>
                         <span id="monthly-date-info" class="field-help"></span>
                     </label>
                 </div>
 
                 <label>
-                    <input type="radio" name="monthly_option" value="by_weekday">
+                    <input type="radio" name="monthly_option" value="by_weekday"
+                    {% if form.day_of_week.value or form.nth_weekday.value %}checked{% endif %}>
                     <span id="monthly-weekday-info" class="field-help"></span>
                 </label>
 
@@ -116,13 +128,15 @@
             <div class="yearly-options">
                 <div class="margin10">
                     <label>
-                        <input type="radio" name="yearly_option" value="by_date" checked>
+                        <input type="radio" name="yearly_option" value="by_date"
+                        {% if not form.day_of_week.value and not form.nth_weekday.value %}checked{% endif %}>
                         <span id="yearly-date-info" class="field-help"></span>
                     </label>
                 </div>
 
                 <label>
-                    <input type="radio" name="yearly_option" value="by_weekday">
+                    <input type="radio" name="yearly_option" value="by_weekday"
+                    {% if form.day_of_week.value or form.nth_weekday.value %}checked{% endif %}>
                     <span id="yearly-weekday-info" class="field-help"></span>
                 </label>
 


### PR DESCRIPTION
### できるようになったこと
1. 繰り返しスケジュール編集を行うときにDB上のデータを画面上のフォームに反映。
2. 過去の日付からスケジュールの新規登録を行うときは開始日にデフォルトで今日の日付を設定、今日以降の未来の日付から登録するときは登録ボタンを押した日付が開始日に設定される。
カレンダーから登録を行うときは今日の日付が開始日に設定される。
開始日の変更自体は可能。